### PR TITLE
Implementación de Soporte para Municipios en el Módulo de eCommerce Cubano (Staging.saas 17.0)

### DIFF
--- a/l10n_cu_address/models/res_state.py
+++ b/l10n_cu_address/models/res_state.py
@@ -1,8 +1,9 @@
 # -*- coding: utf-8 -*-
 
-from odoo import models, fields 
+from odoo import models, fields
+
 
 class State(models.Model):
     _inherit = 'res.country.state'
 
-    res_municipality_id = fields.Many2one('res.municipality', 'Municipio', help="Municipios de Cuba")
+    res_municipality_id = fields.One2many('res.municipality', 'state_id', 'Municipio', help="Municipios de Cuba")

--- a/l10n_cu_website_sale/__init__.py
+++ b/l10n_cu_website_sale/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import controllers
+from . import models

--- a/l10n_cu_website_sale/__manifest__.py
+++ b/l10n_cu_website_sale/__manifest__.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "l10n_cu_website_sale",
+    'summary': "Improve eCommerce in Cuba, adding support for addresses and municipalities.",
+    'description': """
+        The `l10n_cu_website_sale` module is designed to enhance eCommerce in Cuba, facilitating the management of 
+        addresses and the integration of municipalities in the purchasing process.
+        It provides a structure adapted to local needs, allowing companies to offer a more precise and personalized 
+        shopping experience.
+        This module is essential to optimize online sales, ensuring that addresses are handled appropriately 
+        according to the Cuban context.
+    """,
+    "author": "Idola Odoo Team, Comunidad cubana de Odoo",
+    'category': 'Website/Website',
+    'version': '17.0.0.1',
+    'depends': ['base', 'website_sale', 'l10n_cu_address'],
+    'data': [
+        'data/res_country_data.xml',
+        'data/ir_model_fields.xml',
+        'views/res_country_views.xml',
+        'views/delivery_carrier_views.xml',
+        'views/templates.xml',
+    ],
+    "assets": {
+        'web.assets_frontend': [
+            'l10n_cu_website_sale/static/src/**/*',
+        ],
+    },
+    "auto_install": False,
+    "application": False,
+    "license": "AGPL-3",
+
+}

--- a/l10n_cu_website_sale/controllers/__init__.py
+++ b/l10n_cu_website_sale/controllers/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import main

--- a/l10n_cu_website_sale/controllers/main.py
+++ b/l10n_cu_website_sale/controllers/main.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+class L10nCuWebsiteSale(WebsiteSale):
+
+    def _get_country_related_render_values(self, kw, render_values):
+        """ Provide the fields related to the country to render the website sale form """
+
+        res = super(L10nCuWebsiteSale, self)._get_country_related_render_values(kw, render_values)
+        mode = render_values['mode']
+        Partner = request.env['res.partner']
+        partner_id = render_values['partner_id']
+
+        if mode and partner_id != -1:
+            Partner = Partner.browse(int(render_values['partner_id']))
+
+        res['state_id'] = Partner.state_id
+        res['municipalities'] = Partner.state_id.get_website_sale_municipalities(mode=mode[1])
+
+        return res
+
+    def _get_mandatory_fields_billing(self, country_id=False):
+        req = super(L10nCuWebsiteSale, self)._get_mandatory_fields_billing(country_id=country_id)
+        if country_id:
+            country = request.env['res.country'].browse(country_id)
+            if country.municipality_required:
+                req += ['res_municipality_id']
+            if not country.city_required:
+                req.remove('city')
+
+        return req
+
+    def _get_mandatory_fields_shipping(self, country_id=False):
+        req = super(L10nCuWebsiteSale, self)._get_mandatory_fields_shipping(country_id=country_id)
+        if country_id:
+            country = request.env['res.country'].browse(country_id)
+            if country.municipality_required:
+                req += ['res_municipality_id']
+            if not country.city_required:
+                req.remove('city')
+
+        return req
+
+    @http.route(['/shop/l10n_cu/state_infos/<model("res.country.state"):state>'], type="json", auth="public", methods=["POST"], website=True,)
+    def l10n_cu_state_infos(self, state, mode, **kw):
+
+        municipalities = state.get_website_sale_municipalities(mode=mode)
+
+        return {'municipalities': [(c.id, c.name, c.code) for c in municipalities]}

--- a/l10n_cu_website_sale/data/ir_model_fields.xml
+++ b/l10n_cu_website_sale/data/ir_model_fields.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <function model="ir.model.fields" name="formbuilder_whitelist">
+        <value>res.partner</value>
+        <value eval="[
+            'res_municipality_id'
+        ]"/>
+    </function>
+
+</odoo>

--- a/l10n_cu_website_sale/data/res_country_data.xml
+++ b/l10n_cu_website_sale/data/res_country_data.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <data noupdate="1">
+        <record id="base.cu" model="res.country">
+            <field eval="'%(street)s\n%(street2)s\n%(city)s\n%(municipality_name)s %(state_name)s %(zip)s\n%(country_name)s'" name="address_format" />
+            <field name="state_required" eval="True"/>
+            <field name="city_required" eval="False"/>
+            <field name="municipality_required" eval="True"/>
+        </record>
+    </data>
+</odoo>

--- a/l10n_cu_website_sale/models/__init__.py
+++ b/l10n_cu_website_sale/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+
+from . import delivery_carrier
+from . import res_country_state
+from . import res_partner
+from . import res_country

--- a/l10n_cu_website_sale/models/delivery_carrier.py
+++ b/l10n_cu_website_sale/models/delivery_carrier.py
@@ -1,0 +1,14 @@
+from odoo import api, fields, models, _, Command
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    municipality_ids = fields.Many2many('res.municipality', 'delivery_carrier_mun_rel', 'carrier_id',
+                                        'municipality_id', 'Municipalities')
+
+    @api.onchange('state_ids')
+    def _onchange_state_ids(self):
+        self.municipality_ids -= self.municipality_ids.filtered(
+            lambda state: state._origin.id not in self.state_ids.res_municipality_id.ids
+        )

--- a/l10n_cu_website_sale/models/res_country.py
+++ b/l10n_cu_website_sale/models/res_country.py
@@ -1,0 +1,9 @@
+from odoo import api, fields, models, _
+
+
+class ResCountry(models.Model):
+    _inherit = 'res.country'
+
+    city_required = fields.Boolean(default=True)
+    municipality_required = fields.Boolean(default=False)
+

--- a/l10n_cu_website_sale/models/res_country_state.py
+++ b/l10n_cu_website_sale/models/res_country_state.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+
+from odoo import models
+
+
+class ResCountryState(models.Model):
+    _inherit = 'res.country.state'
+
+    def get_website_sale_municipalities(self, mode='billing'):
+        res = self.sudo().res_municipality_id
+        if mode == 'shipping':
+            municipalities = self.env['res.municipality']
+            dom = ['|', ('state_ids', 'in', self.id), ('state_ids', '=', False), ('website_published', '=', True)]
+            delivery_carriers = self.env['delivery.carrier'].sudo().search(dom)
+
+            for carrier in delivery_carriers:
+                if not carrier.state_ids or not carrier.municipality_ids:
+                    municipalities = res
+                    break
+                municipalities |= carrier.municipality_ids
+            res = res & municipalities
+        return res

--- a/l10n_cu_website_sale/models/res_partner.py
+++ b/l10n_cu_website_sale/models/res_partner.py
@@ -1,0 +1,52 @@
+import inspect
+
+from odoo import models
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    def _ignore_methods_name_list(self):
+        """
+        Returns a list of method names where, when calling _formatting_address_fields,
+        the `municipality_name` will not be added to avoid errors.
+        This method is useful for understanding which specific functions are excluded from the formatting process,
+        allowing better control over data handling in situations where the inclusion of `municipality_name`
+        would cause problems.
+
+        :return: List of method names to be ignored
+        :rtype: list
+        """
+
+        return ['_prepare_display_address']
+
+    def _formatting_address_fields(self):
+        """Returns the list of address fields usable to format addresses."""
+        fields_values = super(ResPartner, self)._formatting_address_fields()
+        caller = inspect.stack()[1].function
+
+        if caller not in self._ignore_methods_name_list():
+            fields_values += ['municipality_name']
+
+        return fields_values
+
+    def _display_address_depends(self):
+        """
+        :return: field dependencies of method _display_address()
+        """
+        # remove 'municipality_name' to prevent api.depends error
+        fields_values = super(ResPartner, self)._display_address_depends()
+        fields_values.remove('municipality_name')
+        return fields_values
+
+    def _prepare_display_address(self, without_company=False):
+        """
+        get the information that will be injected into the display format
+        get the address format
+        :param without_company:
+        :return:
+        """
+
+        address_format, args = super(ResPartner, self)._prepare_display_address(without_company=without_company)
+        args['municipality_name'] = self.res_municipality_id.name or ''
+        return address_format, args

--- a/l10n_cu_website_sale/static/src/js/webiste_sale.js
+++ b/l10n_cu_website_sale/static/src/js/webiste_sale.js
@@ -1,0 +1,92 @@
+// /** @odoo-module **/
+// import {WebsiteSale} from "@website_sale/js/website_sale";
+//
+// WebsiteSale.include({
+//     events: Object.assign({}, WebsiteSale.prototype.events, {
+//         "change select[name='city_id']": "_onChangeCity",
+//     }),
+//     start: function () {
+//         this.elementCities = document.querySelector("select[name='city_id']");
+//         this.elementDistricts = document.querySelector("select[name='l10n_pe_district']");
+//         this.cityBlock = document.querySelector(".div_city");
+//         this.autoFormat = document.querySelector(".checkout_autoformat");
+//         this.elementState = document.querySelector("select[name='state_id']");
+//         this.elemenCountry = document.querySelector("select[name='country_id']");
+//         this.isPeruvianCompany = this.elemenCountry?.dataset.company_country_code === 'PE';
+//         return this._super.apply(this, arguments);
+//     },
+//     _changeOption: function (selectCheck, rpcRoute, place, selectElement) {
+//         if (!selectCheck) {
+//             return;
+//         }
+//         return this.rpc(rpcRoute, {
+//         }).then((data) => {
+//             if (this.isPeruvianCompany) {
+//                 if (data[place]?.length) {
+//                     selectElement.innerHTML = "";
+//                     data[place].forEach((item) => {
+//                         let opt = document.createElement("option");
+//                         opt.textContent = item[1];
+//                         opt.value = item[0];
+//                         opt.setAttribute("data-code", item[2]);
+//                         selectElement.appendChild(opt);
+//                     });
+//                     selectElement.parentElement.style.display = "block";
+//                 } else {
+//                     selectElement.value = "";
+//                     selectElement.parentElement.style.display = "none";
+//                 }
+//             }
+//         });
+//     },
+//     _onChangeState: function (ev) {
+//         return this._super.apply(this, arguments).then(() => {
+//             let selectedCountry = this.elemenCountry.options[this.elemenCountry.selectedIndex].getAttribute("code");
+//             if (this.isPeruvianCompany && selectedCountry === "PE") {
+//                 if (this.elementState.value === "" && this.elemenCountry.value !== '') {
+//                     this.elementState.options[1].selected = true;
+//                 }
+//                 const state = this.elementState.value;
+//                 const rpcRoute = `/shop/state_infos/${state}`;
+//                 return this.autoFormat.length
+//                     ? this._changeOption(state, rpcRoute, "cities", this.elementCities).then(() => this._onChangeCity())
+//                     : undefined;
+//             }
+//         });
+//     },
+//     _onChangeCity: function () {
+//         if (this.isPeruvianCompany) {
+//             const city = this.elementCities.value;
+//             const rpcRoute = `/shop/city_infos/${city}`;
+//             return this.autoFormat.length
+//                 ? this._changeOption(city, rpcRoute, "districts", this.elementDistricts)
+//                 : undefined;
+//         }
+//     },
+//     _onChangeCountry: function (ev) {
+//         return this._super.apply(this, arguments).then(() => {
+//             if (this.isPeruvianCompany) {
+//                 let selectedCountry = ev.currentTarget.options[ev.currentTarget.selectedIndex].getAttribute("code");
+//                 let cityInput = document.querySelector(".form-control[name='city']");
+//                 if (selectedCountry == "PE") {
+//                     if (cityInput.value) {
+//                         cityInput.value = "";
+//                     }
+//                     this.cityBlock.classList.add("d-none");
+//                     return this._onChangeState().then(() => {
+//                         this._onChangeCity();
+//                     });
+//                 } else {
+//                     this.cityBlock.querySelectorAll("input").forEach((input) => {
+//                         input.value = "";
+//                     });
+//                     this.cityBlock.classList.remove("d-none");
+//                     this.elementCities.value = "";
+//                     this.elementCities.parentElement.style.display = "none";
+//                     this.elementDistricts.value = "";
+//                     this.elementDistricts.parentElement.style.display = "none";
+//                 }
+//             }
+//         });
+//     },
+// });

--- a/l10n_cu_website_sale/views/delivery_carrier_views.xml
+++ b/l10n_cu_website_sale/views/delivery_carrier_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_delivery_carrier_form_l10n_cu" model="ir.ui.view">
+        <field name="name">delivery.carrier.l10n.cu.form</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//group[@name='country_details']//field[@name='state_ids']" position="after">
+                <field name="municipality_ids"
+                       widget="many2many_tags"
+                       domain="[('state_id', 'in', state_ids)]"
+                       readonly="not state_ids"
+                       force_save="1"
+                       options="{'no_create': True}"/>
+            </xpath>
+
+
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_cu_website_sale/views/res_country_views.xml
+++ b/l10n_cu_website_sale/views/res_country_views.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+    <record id="view_country_form_l10n_cu" model="ir.ui.view">
+        <field name="name">res.country.form.l10n.cu</field>
+        <field name="model">res.country</field>
+        <field name="inherit_id" ref="base.view_country_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='state_required']" position="after">
+                <field name="municipality_required"/>
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_cu_website_sale/views/templates.xml
+++ b/l10n_cu_website_sale/views/templates.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <template id="l10n_cu_website_sale_address" name="Address Management l10n_cu" inherit_id="website_sale.address">
+        <xpath expr="//form//div[contains(@t-attf-class, 'div_state')]" position="after">
+            <div class="w-100"/>
+            <div t-attf-class="#{error.get('res_municipality_id') and 'o_has_error'} div_municipality col-lg-12 mb-2"
+                 t-att-style="(not state_id or not state_id.res_municipality_id) and 'display: none'">
+                <label class="col-form-label" for="res_municipality_id">Municipality</label>
+                <select name="res_municipality_id" id="res_municipality_id" t-attf-class="form-select #{error.get('res_municipality_id') and 'is-invalid' or ''}"
+                        data-init="1">
+                    <option value="">Municipality...</option>
+                    <t t-foreach="municipalities" t-as="m">
+                        <option t-att-value="m.id"
+                                t-att-selected="m.id == ('res_municipality_id' in checkout and state_id and checkout['res_municipality_id'] != '' and int(checkout['res_municipality_id']))">
+                            <t t-esc="m.name"/>
+                        </option>
+                    </t>
+                </select>
+            </div>
+        </xpath>
+    </template>
+
+</odoo>


### PR DESCRIPTION
**Mejora el eCommerce en Cuba, agregando soporte para direcciones y municipios.**

El módulo `l10n_cu_website_sale` está diseñado para potenciar el comercio electrónico en Cuba, facilitando la gestión de direcciones y la integración de municipios en el proceso de compra. 
Proporciona una estructura adaptada a las necesidades locales, permitiendo que las empresas ofrezcan una experiencia de compra más precisa y personalizada. 
