### PR TITLE
[IMP][17.0] - Se corrige el ocultamiento inmediato del selector de mu…

### DIFF
--- a/l10n_cu_website_sale/controllers/main.py
+++ b/l10n_cu_website_sale/controllers/main.py
@@ -45,9 +45,13 @@ class L10nCuWebsiteSale(WebsiteSale):
 
         return req
 
-    @http.route(['/shop/l10n_cu/state_infos/<model("res.country.state"):state>'], type="json", auth="public", methods=["POST"], website=True,)
+    @http.route(['/shop/l10n_cu/state_infos/<model("res.country.state"):state>'], type="json", auth="public", methods=["POST"], website=True, )
     def l10n_cu_state_infos(self, state, mode, **kw):
 
         municipalities = state.get_website_sale_municipalities(mode=mode)
+        municipality_required = state.country_id.municipality_required
 
-        return {'municipalities': [(c.id, c.name, c.code) for c in municipalities]}
+        return {
+            'municipalities': [(c.id, c.name, c.code) for c in municipalities],
+            'municipality_required': municipality_required
+        }

--- a/l10n_cu_website_sale/models/res_country.py
+++ b/l10n_cu_website_sale/models/res_country.py
@@ -1,9 +1,26 @@
 from odoo import api, fields, models, _
+from odoo.exceptions import UserError
 
 
 class ResCountry(models.Model):
     _inherit = 'res.country'
 
-    city_required = fields.Boolean(default=True)
-    municipality_required = fields.Boolean(default=False)
+    city_required = fields.Boolean(default=True, string='City Required')
+    municipality_required = fields.Boolean(default=False, string='Municipality Required')
 
+    @api.constrains('address_format')
+    def _check_address_format(self):
+        """
+         Override
+        :return:
+        """
+        for record in self:
+            if record.address_format:
+                address_fields = self.env['res.partner']._formatting_address_fields() + ['state_code', 'state_name',
+                                                                                         'country_code',
+                                                                                         'country_name', 'company_name',
+                                                                                         'municipality_name']
+                try:
+                    record.address_format % {i: 1 for i in address_fields}
+                except (ValueError, KeyError):
+                    raise UserError(_('The layout contains an invalid format key'))

--- a/l10n_cu_website_sale/models/res_partner.py
+++ b/l10n_cu_website_sale/models/res_partner.py
@@ -1,43 +1,11 @@
 import inspect
+from collections import defaultdict
 
 from odoo import models
 
 
 class ResPartner(models.Model):
     _inherit = 'res.partner'
-
-    def _ignore_methods_name_list(self):
-        """
-        Returns a list of method names where, when calling _formatting_address_fields,
-        the `municipality_name` will not be added to avoid errors.
-        This method is useful for understanding which specific functions are excluded from the formatting process,
-        allowing better control over data handling in situations where the inclusion of `municipality_name`
-        would cause problems.
-
-        :return: List of method names to be ignored
-        :rtype: list
-        """
-
-        return ['_prepare_display_address']
-
-    def _formatting_address_fields(self):
-        """Returns the list of address fields usable to format addresses."""
-        fields_values = super(ResPartner, self)._formatting_address_fields()
-        caller = inspect.stack()[1].function
-
-        if caller not in self._ignore_methods_name_list():
-            fields_values += ['municipality_name']
-
-        return fields_values
-
-    def _display_address_depends(self):
-        """
-        :return: field dependencies of method _display_address()
-        """
-        # remove 'municipality_name' to prevent api.depends error
-        fields_values = super(ResPartner, self)._display_address_depends()
-        fields_values.remove('municipality_name')
-        return fields_values
 
     def _prepare_display_address(self, without_company=False):
         """

--- a/l10n_cu_website_sale/static/src/js/webiste_sale.js
+++ b/l10n_cu_website_sale/static/src/js/webiste_sale.js
@@ -11,10 +11,21 @@ WebsiteSale.include({
         this._onChangeState = debounce(this._onChangeState.bind(this), 500);
     },
 
-    _onChangeCountry: function (ev) {
-        return this._super.apply(this, arguments).then(() => {
-            $("select[name='state_id']").trigger('change');
-        });
+    /**
+     * Extended to hide municipalities when the region changes
+     * and avoid the slight delay. Afterward, _onChangeState is called again
+     * to synchronize municipalities as soon as the states/provinces are
+     * obtained.
+     *
+     * @private
+     */
+    _changeCountry: function () {
+        let data = {
+            municipalities: []
+        }
+        this._expandDataStates(data);
+        this._super.apply(this, arguments);
+        this._onChangeState(this);
     },
 
     _onChangeState: function (ev) {
@@ -28,7 +39,7 @@ WebsiteSale.include({
             const state = $("select[name='state_id']");
 
             if (state.val() === '' || countryCode !== 'CU') {
-                const data = {
+                let data = {
                     municipalities: []
                 }
                 return this._expandDataStates(data);


### PR DESCRIPTION
…nicipios cuando se cambia la región para evitar retrasos leves en la interfaz.

- Se sincronizan los municipios llamando a _onChangeState tan pronto se obtienen los estados/provincias.
- [REF] Se refactoriza el código para evitar la necesidad de heredar el módulo l10n_cu_website_sale en futuras implementaciones.
- Se agregan métodos que no requieren incluir el campo municipality_name.