### PR TITLE
[IMP][17.0] - Se actualizan las vistas hijas de res.partner (Contacts & Addresses)

### DIFF
--- a/l10n_cu_address/views/res_cu_municipality.xml
+++ b/l10n_cu_address/views/res_cu_municipality.xml
@@ -19,7 +19,11 @@
             <field name="arch" type="xml"> 
 
                 <xpath expr="//field[@name='street2']" position="after">
-                    <field name="res_municipality_id"  placeholder="Municipio..." context="{'state_id': state_id, 'default_state_id': state_id}"/>
+                    <field name="res_municipality_id" options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}" placeholder="Municipio..." context="{'state_id': state_id, 'default_state_id': state_id}"/>
+                </xpath>
+
+                <xpath expr="//page[@name='contact_addresses']//div[hasclass('o_address_format')]//field[@name='street2']" position="after">
+                    <field name="res_municipality_id" options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}" placeholder="Municipio..." context="{'state_id': state_id, 'default_state_id': state_id}"/>
                 </xpath>
 
             </field>


### PR DESCRIPTION
- Se actualizan las vistas hijas de res.partner (Contacts & Addresses) para incluir el campo res_municipality_id.
- Se asegura que la información de municipio esté disponible en los formularios de contacto y dirección.