### PR TITLE
[IMP] l10n_cu_website_sale: Limitar selección country y state  al contexto del widget

### DIFF
--- a/l10n_cu_website_sale/static/src/js/webiste_sale.js
+++ b/l10n_cu_website_sale/static/src/js/webiste_sale.js
@@ -30,13 +30,13 @@ WebsiteSale.include({
 
     _onChangeState: function (ev) {
         return this._super.apply(this, arguments).then(() => {
-            const country = $("select[name='country_id']");
+            const country = this.$el.find("select[name='country_id']");
 
             const selectedOption = country.find('option:selected');
             // const countryCode = selectedOption.attr('code');
             const mode = country.attr('mode');
 
-            const state = $("select[name='state_id']");
+            const state = this.$el.find("select[name='state_id']");
 
             if (state.val() === '') {
                 let data = {
@@ -56,7 +56,7 @@ WebsiteSale.include({
 
     _expandDataStates(data) {
         // populate states and display
-        let selectMunicipalities = $("select[name='res_municipality_id']");
+        let selectMunicipalities = this.$el.find("select[name='res_municipality_id']");
         // dont reload state at first loading (done in qweb)
         if (selectMunicipalities.data('init') === 0 || selectMunicipalities.find('option').length === 1) {
             if (data.municipalities.length || data.municipality_required) {


### PR DESCRIPTION
Este cambio asegura que country y state apunten solo a los elementos correspondientes dentro del widget actual, evitando conflictos con otros elementos similares en el DOM y mejorando la coherencia en la manipulación de los datos.