### PR TITLE
 Corregir selección de municipio asociado al partner

### DIFF
--- a/l10n_cu_website_sale/static/src/js/webiste_sale.js
+++ b/l10n_cu_website_sale/static/src/js/webiste_sale.js
@@ -20,10 +20,14 @@ WebsiteSale.include({
      * @private
      */
     _changeCountry: function () {
-        let data = {
-            municipalities: []
+        let municipalities = this.$el.find("select[name='res_municipality_id']");
+        if (municipalities.data('init') === 0 || municipalities.find('option').length === 1) {
+            let data = {
+                municipalities: []
+            }
+            this._expandDataStates(data);
         }
-        this._expandDataStates(data);
+
         this._super.apply(this, arguments);
         this._onChangeState(this);
     },
@@ -31,14 +35,10 @@ WebsiteSale.include({
     _onChangeState: function (ev) {
         return this._super.apply(this, arguments).then(() => {
             const country = this.$el.find("select[name='country_id']");
-
-            const selectedOption = country.find('option:selected');
-            // const countryCode = selectedOption.attr('code');
             const mode = country.attr('mode');
-
             const state = this.$el.find("select[name='state_id']");
 
-            if (state.val() === '') {
+            if (state.val() === '' || state.val() === null) {
                 let data = {
                     municipalities: []
                 }
@@ -55,9 +55,9 @@ WebsiteSale.include({
     },
 
     _expandDataStates(data) {
-        // populate states and display
+        // populate municipality and display
         let selectMunicipalities = this.$el.find("select[name='res_municipality_id']");
-        // dont reload state at first loading (done in qweb)
+        // dont reload municipality at first loading (done in qweb)
         if (selectMunicipalities.data('init') === 0 || selectMunicipalities.find('option').length === 1) {
             if (data.municipalities.length || data.municipality_required) {
                 selectMunicipalities.html('');

--- a/l10n_cu_website_sale/static/src/js/webiste_sale.js
+++ b/l10n_cu_website_sale/static/src/js/webiste_sale.js
@@ -30,13 +30,13 @@ WebsiteSale.include({
 
     _onChangeState: function (ev) {
         return this._super.apply(this, arguments).then(() => {
-            const country = $("select[name='country_id']");
+            const country = this.$el.find("select[name='country_id']");
 
             const selectedOption = country.find('option:selected');
             // const countryCode = selectedOption.attr('code');
             const mode = country.attr('mode');
 
-            const state = $("select[name='state_id']");
+            const state = this.$el.find("select[name='state_id']");
 
             if (state.val() === '') {
                 let data = {
@@ -56,7 +56,7 @@ WebsiteSale.include({
 
     _expandDataStates(data) {
         // populate states and display
-        let selectMunicipalities = $("select[name='res_municipality_id']");
+        let selectMunicipalities = this.$el.find("select[name='res_municipality_id']");
         // dont reload state at first loading (done in qweb)
         if (selectMunicipalities.data('init') === 0 || selectMunicipalities.find('option').length === 1) {
             if (data.municipalities.length || data.municipality_required) {


### PR DESCRIPTION
Se corrige un error que impedía que el municipio asociado al partner se marcara correctamente en el selector de municipios. Además, se evita la recarga inicial del selector, dado que esto se realiza directamente en la plantilla QWeb.