### PR TITLE
[FW][IMP] delivery_carrier: verificar municipio en coincidencia de dirección

### DIFF
--- a/l10n_cu_website_sale/models/delivery_carrier.py
+++ b/l10n_cu_website_sale/models/delivery_carrier.py
@@ -12,3 +12,9 @@ class DeliveryCarrier(models.Model):
         self.municipality_ids -= self.municipality_ids.filtered(
             lambda state: state._origin.id not in self.state_ids.res_municipality_id.ids
         )
+
+    def _match_address(self, partner):
+        match = super(DeliveryCarrier, self)._match_address(partner)
+        if self.municipality_ids and partner.res_municipality_id not in self.municipality_ids:
+            return False
+        return match

--- a/l10n_cu_website_sale/static/src/js/webiste_sale.js
+++ b/l10n_cu_website_sale/static/src/js/webiste_sale.js
@@ -20,14 +20,11 @@ WebsiteSale.include({
      * @private
      */
     _changeCountry: function () {
-        let municipalities = this.$el.find("select[name='res_municipality_id']");
-        if (municipalities.data('init') === 0 || municipalities.find('option').length === 1) {
-            let data = {
-                municipalities: []
-            }
-            this._expandDataStates(data);
-        }
+        let selectMunicipalities = this.$el.find("select[name='res_municipality_id']");
+        if (selectMunicipalities.data('init') === 0 || selectMunicipalities.find('option').length === 1) {
+            selectMunicipalities.val('').parent('div').hide();
 
+        }
         this._super.apply(this, arguments);
         this._onChangeState(this);
     },


### PR DESCRIPTION
Se agrega una verificación adicional en la función `_match_address` para filtrar los envíos según el municipio del socio (`partner.res_municipality_id`). Si el municipio del socio no está en la lista de municipios permitidos (`municipality_ids`) del transportista, la función devuelve `False`, bloqueando así el envío.

Este cambio asegura que los transportistas puedan restringir sus envíos solo a los municipios específicos en los que operan, mejorando el control de cobertura geográfica.
