### PR TITLE
[FIX] el objeto 'account.account' no tiene el atributo. Módulo l10n_cu_reports

### DIFF
--- a/l10n_cu_reports/reports/report_financial.py
+++ b/l10n_cu_reports/reports/report_financial.py
@@ -97,7 +97,7 @@ class ReportFinancial(models.AbstractModel):
                         'apertura': report.apertura,
                         # 'level': (report.display_detail == 'detail_with_hierarchy' or data.get('display_detail') == 'detail_with_hierarchy') and 4,
                         'level': data.get('display_detail') == 'detail_with_hierarchy' and 4,
-                        'account_type': account.internal_type,
+                        'account_type': account.account_type,
                     }
                     if data['debit_credit']:
                         vals['debit'] = value['debit']


### PR DESCRIPTION

![Screenshot_2024-11-26_19-37-44](https://github.com/user-attachments/assets/107ebb77-5f22-4bb3-a605-5e8e52747feb)

Error en texto lpano
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/report.py", line 120, in report_download
    response = self.report_routes(reportname, converter=converter, context=context, **data)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/mnt/extra-addons/report_xlsx/controllers/main.py", line 49, in report_routes
    return super().report_routes(reportname, docids, converter, **data)
  File "/usr/lib/python3/dist-packages/odoo/http.py", line 734, in route_wrapper
    result = endpoint(self, *args, **params_ok)
  File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/report.py", line 42, in report_routes
    pdf = report.with_context(context)._render_qweb_pdf(reportname, docids, data=data)[0]
  File "/usr/lib/python3/dist-packages/odoo/addons/account/models/ir_actions_report.py", line 61, in _render_qweb_pdf
    return super()._render_qweb_pdf(report_ref, res_ids=res_ids, data=data)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_actions_report.py", line 896, in _render_qweb_pdf
    collected_streams = self._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/usr/lib/python3/dist-packages/odoo/addons/account_edi_ubl_cii/models/ir_actions_report.py", line 65, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/usr/lib/python3/dist-packages/odoo/addons/account_edi/models/ir_actions_report.py", line 14, in _render_qweb_pdf_prepare_streams
    collected_streams = super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/usr/lib/python3/dist-packages/odoo/addons/account/models/ir_actions_report.py", line 20, in _render_qweb_pdf_prepare_streams
    return super()._render_qweb_pdf_prepare_streams(report_ref, data, res_ids=res_ids)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_actions_report.py", line 747, in _render_qweb_pdf_prepare_streams
    html = self.with_context(**additional_context)._render_qweb_html(report_ref, all_res_ids_wo_stream, data=data)[0]
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_actions_report.py", line 970, in _render_qweb_html
    data = self._get_rendering_context(report, docids, data)
  File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_actions_report.py", line 985, in _get_rendering_context
    data.update(report_model._get_report_values(docids, data=data))
  File "/mnt/extra-addons/accounting_pdf_reports/report/report_financial.py", line 157, in _get_report_values
    report_lines = self.get_account_lines(data.get('form'))
  File "/mnt/extra-addons/l10n_cu_reports/reports/report_financial.py", line 100, in get_account_lines
    'account_type': account.internal_type,
AttributeError: 'account.account' object has no attribute 'internal_type'

The above server error caused the following client error:
RPC_ERROR: Odoo Server Error
    RPC_ERROR
```