### PR TITLE
[Fix] cambio de AccountChartTemplate(models.Model) a AccountChartTemplate(models.AbstractModel)

### DIFF
--- a/l10n_cu/models/account.py
+++ b/l10n_cu/models/account.py
@@ -32,7 +32,7 @@ class AccountAccountTag(models.Model):
     nature = fields.Selection([
         ('D', 'Debitable Account'), ('A', 'Creditable Account')])
 
-class AccountChartTemplate(models.Model):
+class AccountChartTemplate(models.AbstractModel):
     _inherit = "account.chart.template"
     
 


### PR DESCRIPTION
Corrige el error 
```TypeError: <class 'odoo.addons.l10n_cu.models.account.AccountChartTemplate'> transforms the abstract model 'account.chart.template' into a non-abstract model. That class should either inherit from AbstractModel, or set a different '_name'.```
El modelo account.chart.template es abstracto, por lo que la clase heredada debe usar models.AbstractModel.

Cambios realizados:
Se cambió la herencia de models.Model a models.AbstractModel en l10n_cu/models/account.py.