### PR TITLE
[Fix] Remplazo de 'account.group.template' por 'account.group'.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,9 @@ dmypy.json
 
 #macOS
 .DS_Store
+
+# JetBrains IDEs (PyCharm, IntelliJ IDEA)
+.idea/
+*.iml
+*.iws
+*.ipr

--- a/l10n_cu/models/account.py
+++ b/l10n_cu/models/account.py
@@ -97,7 +97,7 @@ class AccountChartTemplate(models.AbstractModel):
         return journals_to_create[1:]
 
 class AccountGroupTemplate(models.Model):
-    _inherit = "account.group.template"
+    _inherit = "account.group"
 
     reconcile = fields.Boolean(string='Allow Reconciliation')   
     expense_element_detailed = fields.Boolean()

--- a/l10n_cu/models/chart_template.py
+++ b/l10n_cu/models/chart_template.py
@@ -38,11 +38,11 @@ def preserve_existing_tags_on_taxes(cr, registry, module):
 
 
 class AccountGroupTemplate(models.Model):
-    _name = "account.group.template"
+    _name = "account.group"
     _description = 'Template for Account Groups'
     _order = 'code_prefix_start'
 
-    parent_id = fields.Many2one('account.group.template', ondelete='cascade')
+    parent_id = fields.Many2one('account.group', ondelete='cascade')
     name = fields.Char(required=True)
     code_prefix_start = fields.Char()
     code_prefix_end = fields.Char()
@@ -764,7 +764,7 @@ class AccountChartTemplate(models.Model):
         :param company: company to generate the account groups for
         """
         self.ensure_one()
-        group_templates = self.env['account.group.template'].search([('chart_template_id', '=', self.id)])
+        group_templates = self.env['account.group'].search([('chart_template_id', '=', self.id)])
         template_vals = []
         for group_template in group_templates:
             vals = {


### PR DESCRIPTION
En Odoo 17 se ha fusionado el modelo  'account.group.template' en 'account.group'.

Este [FIX] resuelve el Issue #50 que mostraba el siguiente errror:

```
RPC_ERROR
Odoo Server Error
Traceback (most recent call last):
File "/usr/lib/python3/dist-packages/odoo/http.py", line 1788, in _serve_db
return service_model.retrying(self._serve_ir_http, self.env)
File "/usr/lib/python3/dist-packages/odoo/service/model.py", line 152, in retrying
result = func()
File "/usr/lib/python3/dist-packages/odoo/http.py", line 1816, in _serve_ir_http
response = self.dispatcher.dispatch(rule.endpoint, args)
File "/usr/lib/python3/dist-packages/odoo/http.py", line 2020, in dispatch
result = self.request.registry['ir.http']._dispatch(endpoint)
File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_http.py", line 221, in _dispatch
result = endpoint(**request.params)
File "/usr/lib/python3/dist-packages/odoo/http.py", line 757, in route_wrapper
result = endpoint(self, *args, **params_ok)
File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 29, in call_button
action = self._call_kw(model, method, args, kwargs)
File "/usr/lib/python3/dist-packages/odoo/addons/web/controllers/dataset.py", line 21, in _call_kw
return call_kw(Model, method, args, kwargs)
File "/usr/lib/python3/dist-packages/odoo/api.py", line 484, in call_kw
result = _call_kw_multi(method, model, args, kwargs)
File "/usr/lib/python3/dist-packages/odoo/api.py", line 469, in _call_kw_multi
result = method(recs, *args, **kwargs)
File "", line 2, in button_immediate_install
File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_module.py", line 75, in check_and_log
return method(self, *args, **kwargs)
File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_module.py", line 469, in button_immediate_install
return self._button_immediate_function(self.env.registry[self._name].button_install)
File "/usr/lib/python3/dist-packages/odoo/addons/base/models/ir_module.py", line 593, in _button_immediate_function
registry = modules.registry.Registry.new(self._cr.dbname, update_module=True)
File "", line 2, in new
File "/usr/lib/python3/dist-packages/odoo/tools/func.py", line 87, in locked
return func(inst, *args, **kwargs)
File "/usr/lib/python3/dist-packages/odoo/modules/registry.py", line 110, in new
odoo.modules.load_modules(registry, force_demo, status, update_module)
File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 485, in load_modules
processed_modules += load_marked_modules(env, graph,
File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 366, in load_marked_modules
loaded, processed = load_module_graph(
File "/usr/lib/python3/dist-packages/odoo/modules/loading.py", line 196, in load_module_graph
model_names = registry.load(env.cr, package)
File "/usr/lib/python3/dist-packages/odoo/modules/registry.py", line 267, in load
model = cls._build_model(self, cr)
File "/usr/lib/python3/dist-packages/odoo/models.py", line 720, in _build_model
raise TypeError("Model %r does not exist in registry." % name)
TypeError: Model 'account.group.template' does not exist in registry.
```