### PR TITLE
[REF] l10n_cu_address: renombrar campos de municipio

### DIFF
--- a/l10n_cu_address/migrations/20.0.1/end-migrate_fix_municipalities.py
+++ b/l10n_cu_address/migrations/20.0.1/end-migrate_fix_municipalities.py
@@ -6,11 +6,11 @@ def migrate(cr, version):
 
     env.cr.execute("""
         UPDATE res_partner
-        SET res_municipality_id = NULL
-        WHERE res_municipality_id IS NOT NULL
+        SET municipality_id = NULL
+        WHERE municipality_id IS NOT NULL
           AND (
               state_id IS NULL
-              OR res_municipality_id NOT IN (
+              OR municipality_id NOT IN (
                   SELECT id
                   FROM res_municipality
                   WHERE state_id = res_partner.state_id

--- a/l10n_cu_address/models/res_partner.py
+++ b/l10n_cu_address/models/res_partner.py
@@ -6,63 +6,20 @@ from odoo import models, fields, api
 class Partner(models.Model):
     _inherit = 'res.partner'
 
-    res_municipality_id = fields.Many2one('res.municipality', 'Municipio', domain="[('state_id', '=', state_id)]",
-                                          help="Municipios de Cuba")
+    municipality_id = fields.Many2one(
+        'res.municipality',
+        'Municipio',
+        domain="[('state_id', '=', state_id)]",
+        help="Municipios de Cuba"
+    )
 
-    municipality_name = fields.Char(string="Nombre del Municipio", related='res_municipality_id.name')
+    municipality_name = fields.Char(string="Nombre del Municipio", related='municipality_id.name')
 
     @api.onchange('state_id')
     def _onchange_state_id(self):
-        if self.res_municipality_id not in self.state_id.res_municipality_ids:
-            self.res_municipality_id = False
+        if self.municipality_id not in self.state_id.municipality_ids:
+            self.municipality_id = False
 
     @api.model
     def _address_fields(self):
         return super()._address_fields() + ['municipality_name']
-
-    def _sanitize_municipality_id(self, vals):
-        """Sanitize the municipality value based on the selected state.
-
-        Ensures that ``res_municipality_id`` is only kept in ``vals`` when it
-        actually belongs to the state referenced by ``state_id``. This
-        prevents inconsistent data where a municipality from one state is
-        linked to a record with a different (or no) state assigned.
-
-        :param dict vals: values dictionary passed to create/write, expected
-            to optionally contain 'res_municipality_id' and 'state_id'.
-        :return: the same vals dictionary, with 'res_municipality_id' set to
-            None when it does not belong to the given state.
-        :rtype: dict
-        """
-        if 'res_municipality_id' in vals:
-            municipality_id = vals['res_municipality_id']
-            state_id = self.env['res.country.state'].browse(
-                vals.get('state_id')
-            ).exists()
-            if not state_id or not municipality_id in state_id.res_municipality_id.ids:
-                vals['res_municipality_id'] = None
-        return vals
-
-    def write(self, vals):
-        """Override write to sanitize 'res_municipality_id' before saving.
-
-        :param dict vals: values to write on the record(s).
-        :return: True if was successful.
-        :rtype: bool
-        """
-        vals.update(self._sanitize_municipality_id(vals))
-        return super().write(vals)
-
-    @api.model_create_multi
-    def create(self, vals_list):
-        """Override create to sanitize 'res_municipality_id' for each record.
-
-        :param list[dict] vals_list: list of values dictionaries for the
-            records to create.
-        :return: the newly created record(s).
-        :rtype: recordset
-        """
-        for vals in vals_list:
-            vals.update(self._sanitize_municipality_id(vals))
-
-        return super().create(vals_list)

--- a/l10n_cu_address/models/res_state.py
+++ b/l10n_cu_address/models/res_state.py
@@ -6,4 +6,6 @@ from odoo import models, fields
 class State(models.Model):
     _inherit = 'res.country.state'
 
-    res_municipality_ids = fields.One2many('res.municipality', 'state_id', 'Municipio', help="Municipios de Cuba")
+    municipality_ids = fields.One2many(
+        'res.municipality', 'state_id', 'Municipio', help="Municipios de Cuba"
+    )

--- a/l10n_cu_address/views/res_partner_views.xml
+++ b/l10n_cu_address/views/res_partner_views.xml
@@ -7,13 +7,13 @@
         <field name="arch" type="xml">
 
             <xpath expr="//field[@name='street2']" position="after">
-                <field name="res_municipality_id"
+                <field name="municipality_id"
                        options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}"
                        placeholder="Municipio..." context="{'state_id': state_id, 'default_state_id': state_id}"/>
             </xpath>
             <xpath expr="//page[@name='contact_addresses']//div[hasclass('o_address_format')]//field[@name='street2']"
                    position="after">
-                <field name="res_municipality_id"
+                <field name="municipality_id"
                        options="{'no_create': True, 'no_edit': True, 'no_quick_create': True}"
                        placeholder="Municipio..." context="{'state_id': state_id, 'default_state_id': state_id}"/>
             </xpath>


### PR DESCRIPTION
Los campos `res_municipality_id` y `res_municipality_ids` usaban el prefijo `res_` de forma innecesaria, lo cual no aporta claridad y es inconsistente con la convención de nombres del resto del módulo.

Se renombraron a `municipality_id` y `municipality_ids` respectivamente para simplificar la nomenclatura y mantener consistencia con el resto del código.

Nota: En una versión anterior (17.0) se introdujo el método `_sanitize_municipality_id` ahora ha sido removido debido a que era un fix temporal.