### PR TITLE
[ADD] l10n_cu_website_sale: agregar módulo desde la rama 17.0

### DIFF
--- a/l10n_cu_website_sale/__init__.py
+++ b/l10n_cu_website_sale/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+
+from . import controllers
+from . import models

--- a/l10n_cu_website_sale/__manifest__.py
+++ b/l10n_cu_website_sale/__manifest__.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+{
+    'name': "l10n_cu_website_sale",
+    'summary': "Improve eCommerce in Cuba, adding support for addresses and municipalities.",
+    'description': """
+        The `l10n_cu_website_sale` module is designed to enhance eCommerce in Cuba, facilitating the management of 
+        addresses and the integration of municipalities in the purchasing process.
+        It provides a structure adapted to local needs, allowing companies to offer a more precise and personalized 
+        shopping experience.
+        This module is essential to optimize online sales, ensuring that addresses are handled appropriately 
+        according to the Cuban context.
+    """,
+    "author": "Idola Odoo Team, Comunidad cubana de Odoo",
+    'category': 'Website/Website',
+    'version': '2.0',
+    'depends': ['base', 'website_sale', 'l10n_cu_address'],
+    'data': [
+        'data/ir_model_fields.xml',
+        'views/delivery_carrier_views.xml',
+        'views/templates.xml',
+    ],
+    "assets": {
+        'web.assets_frontend': [
+            'l10n_cu_website_sale/static/src/**/*',
+        ],
+    },
+    "auto_install": False,
+    "application": False,
+    "license": "AGPL-3",
+
+}

--- a/l10n_cu_website_sale/controllers/__init__.py
+++ b/l10n_cu_website_sale/controllers/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import main

--- a/l10n_cu_website_sale/controllers/main.py
+++ b/l10n_cu_website_sale/controllers/main.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+from odoo import http
+from odoo.http import request
+
+from odoo.addons.website_sale.controllers.main import WebsiteSale
+
+
+class L10nCuWebsiteSale(WebsiteSale):
+
+    def _l10n_cu_validate_fiscal_country(self):
+        """Devuelve el parámetro de configuración que controla si la lógica de campos
+        obligatorios específica de Cuba (municipality_id en lugar de city) debe
+        aplicarse únicamente cuando el país fiscal de la compañía del sitio web
+        sea Cuba.
+
+        Cuando este parámetro está activado, se toma el país fiscal de la compañía
+        como fuente de verdad para decidir si aplican las reglas de dirección
+        cubanas. Cuando está desactivado (comportamiento por defecto), las reglas
+        se aplican únicamente basándose en el país de destino seleccionado por el
+        cliente, sin importar el país fiscal de la compañía.
+        """
+        return request.env['ir.config_parameter'].sudo()._get_param(
+            'l10n_cu_website_sale.rquire_company_fiscal_country'
+        )
+
+    def _get_mandatory_delivery_address_fields(self, country_sudo):
+        mandatory_fields = super()._get_mandatory_delivery_address_fields(country_sudo)
+
+        check_fiscal_country = self._l10n_cu_validate_fiscal_country()
+
+        # En Odoo, los addons específicos de país o región suelen asumir que
+        # el país fiscal de la compañía coincide con el país que se está
+        # validando, para así aplicar sus restricciones o validaciones. Sin
+        # embargo, esta suposición no siempre se cumple: la compañía de un
+        # sitio web puede estar registrada en España y aun así realizar
+        # entregas en Cuba. En ese escenario, basarse únicamente en el país
+        # fiscal dejaría sin exigir el municipality_id en las direcciones de
+        # entrega cubanas. Este parámetro permite sobrescribir ese
+        # comportamiento para poder seguir aplicando la validación específica
+        # de Cuba en función del país de destino, independientemente del país
+        # fiscal de la compañía.
+        if bool(check_fiscal_country) and request.website.sudo().company_id.country_id.code != 'CU':
+            return mandatory_fields
+
+        if country_sudo.code == 'CU':
+            mandatory_fields |= {'municipality_id'}
+            mandatory_fields.remove('city')
+
+        return mandatory_fields
+
+    def _get_mandatory_billing_address_fields(self, country_sudo):
+        """Extend mandatory fields to add the vat in case the website and the customer are from cuba"""
+        mandatory_fields = super()._get_mandatory_billing_address_fields(country_sudo)
+
+        check_fiscal_country = self._l10n_cu_validate_fiscal_country()
+
+        # Ver _get_mandatory_delivery_address_fields: el país fiscal de la
+        # compañía no siempre representa los países que realmente atiende el
+        # sitio web, por lo que esta validación puede omitirse mediante
+        # configuración para seguir exigiendo los campos obligatorios
+        # específicos de Cuba.
+        if bool(check_fiscal_country) and request.website.sudo().company_id.country_id.code != 'CU':
+            return mandatory_fields
+
+        if country_sudo.code == 'CU':
+            mandatory_fields |= {'municipality_id'}
+            mandatory_fields.remove('city')
+
+        return mandatory_fields
+
+    def _prepare_address_form_values(self, order_sudo, partner_sudo, *args, address_type, **kwargs):
+        rendering_values = super()._prepare_address_form_values(
+            order_sudo, partner_sudo, *args, address_type=address_type, **kwargs
+        )
+        rendering_values.update({
+            'municipality_id': partner_sudo.municipality_id.id,
+            'state_municipalities': partner_sudo.state_id.municipality_ids,
+        })
+        return rendering_values
+
+    @http.route(['/shop/l10n_cu/state_infos/<model("res.country.state"):state>'], type="json", auth="public", methods=["POST"], website=True, )
+    def l10n_cu_state_infos(self, state, **kw):
+        municipalities = request.env['res.municipality'].sudo().search([('state_id', '=', state.id)])
+        return {'municipalities': [(c.id, c.name, c.code) for c in municipalities]}

--- a/l10n_cu_website_sale/data/ir_model_fields.xml
+++ b/l10n_cu_website_sale/data/ir_model_fields.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <function model="ir.model.fields" name="formbuilder_whitelist">
+        <value>res.partner</value>
+        <value eval="[
+            'municipality_id'
+        ]"/>
+    </function>
+
+</odoo>

--- a/l10n_cu_website_sale/i18n/es.po
+++ b/l10n_cu_website_sale/i18n/es.po
@@ -1,0 +1,103 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* l10n_cu_website_sale
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 17.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-04-09 02:16+0000\n"
+"PO-Revision-Date: 2025-04-08 22:18-0400\n"
+"Last-Translator: \n"
+"Language-Team: \n"
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+"X-Generator: Poedit 3.6\n"
+
+#. module: l10n_cu_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_cu_website_sale.l10n_cu_website_sale_address
+msgid "<option value=\"\">Municipality...</option>"
+msgstr "<option value=\"\">Municipio...</option>"
+
+#. module: l10n_cu_website_sale
+#: model:ir.model.fields,field_description:l10n_cu_website_sale.field_res_country__city_required
+msgid "City Required"
+msgstr "Ciudad requerida"
+
+#. module: l10n_cu_website_sale
+#: model:ir.model,name:l10n_cu_website_sale.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: l10n_cu_website_sale
+#: model:ir.model,name:l10n_cu_website_sale.model_res_country
+msgid "Country"
+msgstr "País"
+
+#. module: l10n_cu_website_sale
+#: model:ir.model,name:l10n_cu_website_sale.model_res_country_state
+msgid "Country state"
+msgstr "Provincia del país"
+
+#. module: l10n_cu_website_sale
+#. odoo-python
+#: code:addons/l10n-cuba/l10n_cu_website_sale/controllers/main.py:0
+#: code:addons/l10n_cu_website_sale/controllers/main.py:0
+#, python-format
+msgid "Invalid Municipality. Please select a valid Municipality."
+msgstr "Municipio no válido. Por favor, seleccione un municipio válido."
+
+#. module: l10n_cu_website_sale
+#. odoo-python
+#: code:addons/l10n-cuba/l10n_cu_website_sale/controllers/main.py:0
+#: code:addons/l10n_cu_website_sale/controllers/main.py:0
+#, python-format
+msgid "Invalid country or state ID."
+msgstr "ID de país o estado no válido."
+
+#. module: l10n_cu_website_sale
+#: model:ir.model.fields,field_description:l10n_cu_website_sale.field_delivery_carrier__municipality_ids
+msgid "Municipalities"
+msgstr "Municipios"
+
+#. module: l10n_cu_website_sale
+#. odoo-python
+#: code:addons/l10n-cuba/l10n_cu_website_sale/controllers/main.py:0
+#: code:addons/l10n_cu_website_sale/controllers/main.py:0
+#, python-format
+msgid "Municipality ID must be a valid integer."
+msgstr "El ID del municipio debe ser un número entero válido."
+
+#. module: l10n_cu_website_sale
+#: model:ir.model.fields,field_description:l10n_cu_website_sale.field_res_country__municipality_required
+msgid "Municipality Required"
+msgstr "Municipio requerido"
+
+#. module: l10n_cu_website_sale
+#: model:ir.model,name:l10n_cu_website_sale.model_delivery_carrier
+msgid "Shipping Methods"
+msgstr "Métodos de envío"
+
+#. module: l10n_cu_website_sale
+#. odoo-python
+#: code:addons/l10n-cuba/l10n_cu_website_sale/controllers/main.py:0
+#: code:addons/l10n_cu_website_sale/controllers/main.py:0
+#, python-format
+msgid "Some required fields are empty."
+msgstr "Algunos campos requeridos están vacíos."
+
+#. module: l10n_cu_website_sale
+#: model_terms:ir.ui.view,arch_db:l10n_cu_website_sale.l10n_cu_website_sale_address
+msgid "Municipality"
+msgstr "Municipio"
+
+#. module: l10n_cu_website_sale
+#. odoo-python
+#: code:addons/l10n-cuba/l10n_cu_website_sale/models/res_country.py:0
+#: code:addons/l10n_cu_website_sale/models/res_country.py:0
+#, python-format
+msgid "The layout contains an invalid format key"
+msgstr "La presentación contiene una clave de formato no válida"

--- a/l10n_cu_website_sale/models/__init__.py
+++ b/l10n_cu_website_sale/models/__init__.py
@@ -1,0 +1,3 @@
+# -*- coding: utf-8 -*-
+
+from . import delivery_carrier

--- a/l10n_cu_website_sale/models/delivery_carrier.py
+++ b/l10n_cu_website_sale/models/delivery_carrier.py
@@ -1,0 +1,20 @@
+from odoo import api, fields, models, _, Command
+
+
+class DeliveryCarrier(models.Model):
+    _inherit = 'delivery.carrier'
+
+    municipality_ids = fields.Many2many('res.municipality', 'delivery_carrier_mun_rel', 'carrier_id',
+                                        'municipality_id', 'Municipalities')
+
+    @api.onchange('state_ids')
+    def _onchange_state_ids(self):
+        self.municipality_ids -= self.municipality_ids.filtered(
+            lambda state: state._origin.id not in self.state_ids.municipality_ids.ids
+        )
+
+    def _match_address(self, partner):
+        match = super(DeliveryCarrier, self)._match_address(partner)
+        if self.municipality_ids and partner.municipality_id not in self.municipality_ids:
+            return False
+        return match

--- a/l10n_cu_website_sale/static/src/js/address.js
+++ b/l10n_cu_website_sale/static/src/js/address.js
@@ -1,0 +1,57 @@
+/** @odoo-module **/
+
+import websiteSaleAddress from "@website_sale/js/address";
+import { rpc } from "@web/core/network/rpc";
+
+websiteSaleAddress.include({
+    start: function () {
+        this._super.apply(this, arguments);
+
+        this.elementCountry = this.addressForm.country_id;
+        this.elementState = this.addressForm.state_id;
+        this.elementMunicipalities = this.addressForm.municipality_id;
+
+    },
+
+    _changeOption(selectElement, choices) {
+        // empty existing options, only keep the placeholder.
+        selectElement.options.length = 1;
+        if (choices.length) {
+            choices.forEach((item) => {
+                let option = new Option(item[1], item[0]);
+                option.setAttribute('data-code', item[2]);
+                selectElement.appendChild(option);
+            });
+        }
+    },
+
+    async _onChangeState() {
+        await this._super(...arguments);
+        let selectedCountry = this.elementCountry.value ?
+            this.elementCountry.selectedOptions[0].getAttribute('code') : '';
+        if (selectedCountry === "CU") {
+            const stateId = this.elementState.value;
+            let choices = [];
+            if (stateId)  {
+                const data = await rpc(`/shop/l10n_cu/state_infos/${stateId}`, {});
+                choices = data.municipalities;
+            }
+            this._changeOption(this.elementMunicipalities, choices);
+        }
+    },
+
+
+    async _changeCountry(init=false) {
+        await this._super(...arguments);
+        let selectedCountry = this.elementCountry.value ?
+            this.elementCountry.selectedOptions[0].getAttribute('code') : '';
+        if (selectedCountry === 'CU') {
+            this._showInput('municipality_id');
+        } else {
+            // empty existing options, only keep the placeholder.
+            this.elementMunicipalities.options.length = 1;
+            this._hideInput('municipality_id');
+        }
+
+    },
+});

--- a/l10n_cu_website_sale/views/delivery_carrier_views.xml
+++ b/l10n_cu_website_sale/views/delivery_carrier_views.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <record id="view_delivery_carrier_form_l10n_cu" model="ir.ui.view">
+        <field name="name">delivery.carrier.l10n.cu.form</field>
+        <field name="model">delivery.carrier</field>
+        <field name="inherit_id" ref="delivery.view_delivery_carrier_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//group[@name='country_details']//field[@name='state_ids']" position="after">
+                <field name="municipality_ids"
+                       widget="many2many_tags"
+                       domain="[('state_id', 'in', state_ids)]"
+                       readonly="not state_ids"
+                       force_save="1"
+                       options="{'no_create': True}"/>
+            </xpath>
+
+
+        </field>
+    </record>
+
+</odoo>

--- a/l10n_cu_website_sale/views/templates.xml
+++ b/l10n_cu_website_sale/views/templates.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+
+    <template id="l10n_cu_website_sale_address" name="Address Management l10n_cu" inherit_id="website_sale.address">
+        <xpath expr="//div[hasclass('oe_cart')]//div[@id='div_state']" position="after">
+            <div id="div_municipality" class="col-lg-6 mb-2"
+                 t-att-style="not state_municipalities and 'display: none'">
+                <label class="col-form-label" for="o_municipality_id">Municipality</label>
+                <select id="o_municipality_id" name="municipality_id" class="form-select">
+                    <option value="">Municipality...</option>
+                    <t t-foreach="state_municipalities" t-as="m">
+                        <option t-att-value="m.id" t-att-selected="m.id == int(municipality_id)">
+                            <t t-esc="m.name"/>
+                        </option>
+                    </t>
+                </select>
+            </div>
+        </xpath>
+
+        <xpath expr="//t[@t-foreach='countries']//option" position="attributes">
+            <attribute name="t-att-code">c.code</attribute>
+        </xpath>
+    </template>
+
+
+</odoo>


### PR DESCRIPTION
Este addon existía en la rama 17.0 pero nunca fue portado a 18.0, quedando fuera del historial de esa y de ramas posteriores.

Se porta ahora a esta rama, adaptándolo para que sea compatible con esta versión de Odoo, con el objetivo de mantener el histórico completo del módulo entre versiones.

Mantener el addon presente en todas las ramas facilita el seguimiento de cambios via git blame/log, evita reescribir el módulo desde cero en cada versión y permite portar ajustes puntuales de forma más rápida entre ramas en el futuro.