### PR TITLE
[IMP] l10n_cu_pos: se agregan billetes de 2000.00 y 5000.00

### DIFF
--- a/l10n_cu_pos/__init__.py
+++ b/l10n_cu_pos/__init__.py
@@ -8,3 +8,14 @@
 #################################################################################
 
 from . import models
+
+def post_init_hook(cr, registry):
+    from odoo import api, SUPERUSER_ID
+
+    env = api.Environment(cr, SUPERUSER_ID, {})
+    denomination_1 = env.ref('point_of_sale.0_01', raise_if_not_found=False)
+    denomination_2 = env.ref('point_of_sale.0_02', raise_if_not_found=False)
+    denomination_5 = env.ref('point_of_sale.0_05', raise_if_not_found=False)
+
+    denominations = denomination_1 + denomination_2 + denomination_5
+    denominations.write({'pos_config_ids': [(6, 0, [])]})

--- a/l10n_cu_pos/__manifest__.py
+++ b/l10n_cu_pos/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "Cuba - POS",
     "summary": "Implementacion de Punto de Ventas para Cuba.",
     "category": "Point Of Sale",
-    "version": "17.0",
+    "version": "2.0",
     "author": "Comunidad Cubana de Odoo",
     "depends": ['point_of_sale', 'l10n_cu'],
     'license': 'LGPL-3',
@@ -16,5 +16,5 @@
         "data/point_of_sale_data.xml",
         "views/res_partner_views.xml"
     ],
-
+    'post_init_hook': 'post_init_hook',
 }

--- a/l10n_cu_pos/data/point_of_sale_data.xml
+++ b/l10n_cu_pos/data/point_of_sale_data.xml
@@ -1,14 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <delete model="pos.bill" search="[('id', '=', ref('point_of_sale.0_01'))]"/>
-    <delete model="pos.bill" search="[('id', '=', ref('point_of_sale.0_02'))]"/>
-    <delete model="pos.bill" search="[('id', '=', ref('point_of_sale.0_05'))]"/>
-
     <data noupdate="1">
-
         <record model="pos.bill" id="1000_00">
             <field name="name">1000.00</field>
             <field name="value">1000.00</field>
+            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
+        </record>
+        <record model="pos.bill" id="2000_00">
+            <field name="name">2000.00</field>
+            <field name="value">2000.00</field>
+            <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
+        </record>
+        <record model="pos.bill" id="5000_00">
+            <field name="name">5000.00</field>
+            <field name="value">5000.00</field>
             <field name="pos_config_ids" eval="[(6, False, [ref('point_of_sale.pos_config_main')])]"/>
         </record>
     </data>


### PR DESCRIPTION
Se agregaron nuevos registros de billetes para los billetes de 2000.00 y 5000.00, necesarios para cubrir los importes adicionales en efectivo utilizados en el punto de venta.

Como parte de este cambio, se eliminaron los nodos <delete> que previamente eliminaban los registros predeterminados de billetes (0_01, 0_02, 0_05) de point_of_sale. La eliminación de estos registros también borraba sus entradas en ir.model.data, lo que impedía resolver cualquier referencia futura a esos identificadores externos y provocaba fallos en las actualizaciones del módulo en las bases de datos donde ya se había ejecutado la eliminación.